### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ local quicklaunch = require("quicklaunch")
 
 
 -- create widget
-local launchbar = quicklaunch:launchbar {
+local launchbar = quicklaunch:bar {
     { "Mumble",       "mumble.svg",       "mumble",         },
     { "Pidgin",       "pidgin.png",       "pidgin",         },
     { "Konversation", "konversation.png", "konversation",   },


### PR DESCRIPTION
It looks like the main function to create the widget is now `quicklaunch:bar`, not `quicklaunch:launchbar`.